### PR TITLE
Feat: Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+target
+tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,22 @@ jobs:
 
       - name: Build rust
         run: cargo make build
+
+  build-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          default: true
+          override: true
+
+      - name: Install cargo make
+        uses: davidB/rust-cargo-make@v1
+
+      - name: Build Docker
+        run: cargo make docker

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,45 @@ jobs:
         run: |
           echo "🚀 Publishing cargo package"
           cargo make --env CARGO_API_TOKEN="${{ secrets.CARGO_API_TOKEN }}" -- publish
+
+  publish-docker-images:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up context
+        id: project_context
+        uses: FranzDiebold/github-env-vars-action@v2.4.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: docker_metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }},value=${{ env.CI_ACTION_REF_NAME_SLUG }}
+            type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.vendor=OKP4
+      - name: Login to Docker registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DOCKER_REGISTRY_ID }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and publish image(s)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.docker_metadata.outputs.tags }}
+          labels: ${{ steps.docker_metadata.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: [ 'v*' ]
+    tags: ["v*"]
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -37,10 +37,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.4.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -50,13 +46,13 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }},value=${{ env.CI_ACTION_REF_NAME_SLUG }}
             type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
           labels: |
             org.opencontainers.image.vendor=OKP4
+
       - name: Login to Docker registry
         uses: docker/login-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:buster as builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/discord_bot ./bot
+
+ENTRYPOINT ["./bot", "start"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -83,3 +83,8 @@ grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existin
 [tasks.publish]
 args = ["publish", "--token", "${CARGO_API_TOKEN}"]
 command = "cargo"
+
+[tasks.docker]
+args = ["build", "-t", "discord-bot", "."]
+command = "docker"
+description = "Build Docker"


### PR DESCRIPTION
Add a Dockerfile and CI workflows related to Docker build/publish.

Docker build can be triggered via `cargo make docker`. It will build the image `discord-bot:latest`.

Because of the use of an `ENTRYPOINT` in the Dockerfile, you can simply run it with arguments required for the bot to start.
Example:
`docker run discord-bot:latest -t $TOKEN -g $GUILD_ID`