### PR TITLE
Ci/docker improvement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 
@@ -53,7 +53,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
         if: steps.changed-rust-cargo.outputs.any_changed == 'true'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 
@@ -102,7 +102,7 @@ jobs:
         if: steps.changed-rust-files.outputs.any_changed == 'true'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 
@@ -124,7 +124,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 
@@ -155,7 +155,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,16 @@ jobs:
       - name: Lint yaml files
         uses: ibiqlik/action-yamllint@v3.1.0
 
+  lint-dockerfile:
+    runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Lint dockerfile (hadolint)
+        uses: hadolint/hadolint-action@v2.1.0
+
   lint-cargo-toml:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish
 
 on:
   push:
+    branches: [main]
     tags: ["v*"]
 
 concurrency:
@@ -37,34 +38,37 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Extract metadata (tags, labels) for Docker
         id: docker_metadata
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }},${{ github.repository }}
           tags: |
-            type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
+            type=raw,value=nightly
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
           labels: |
             org.opencontainers.image.vendor=OKP4
 
-      - name: Login to Docker registry
+      - name: Login to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ secrets.DOCKER_REGISTRY_ID }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: okp4
+          password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
+
       - name: Build and publish image(s)
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63
           default: true
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license-file = "LICENSE"
 name = "discord_bot"
 readme = "README.md"
 repository = "https://github.com/okp4/discord-bot"
+rust-version = "1.63"
 version = "0.1.0"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ WORKDIR /app
 
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/discord_bot ./bot
 
-ENTRYPOINT ["./bot", "start"]
+ENTRYPOINT ["./bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM rust:buster as builder
+#--- Build stage
+FROM clux/muslrust:1.63.0-stable as builder
 
 WORKDIR /app
 
 COPY . .
 
-RUN cargo build --release
+RUN cargo build --target x86_64-unknown-linux-musl --release
 
-FROM debian:bullseye-slim
+#--- Image stage
+FROM alpine:3.16.2
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/discord_bot ./bot
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/discord_bot ./bot
 
 ENTRYPOINT ["./bot", "start"]


### PR DESCRIPTION
Brings the following improvements: 
- allows docker images to be published on the `main` branch (nightly) - similar to what we've done, for instance with [okp4/cosmos-faucet](https://github.com/okp4/cosmos-faucet/blob/main/.github/workflows/publish.yml).
- fix version of rust to `1.63` (latest available for now) in the CI.
- add missing `lint-dockerfile` lint job - as specified in [okp4/actions](https://github.com/okp4/actions/blob/main/src/.github/workflows/lint.yml#L41).
- use `alpine` docker image for running the bot - similar to what we've done with [okp4/cosmos-faucet](https://github.com/okp4/cosmos-faucet/blob/main/Dockerfile#L11). 
- modify the docker entrypoint to just launch the binary without any command - this way, we can add a configuration file to the bot (thx to @ingvaar).