### PR TITLE
Fix: remove start command from docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /app
 
 COPY --from=builder /app/target/release/discord_bot ./bot
 
-ENTRYPOINT ["./bot", "start"]
+ENTRYPOINT ["./bot"]


### PR DESCRIPTION
Update the dockerfile to just launch the binary without any command.
This way, we can add a configuration file to the bot.