### PR TITLE
⚙️ Fix start with incomplete configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
-#[serde(deny_unknown_fields)]
+#[serde(default)]
 /// Configuration type for the discord bot
 pub struct DiscordBotConfig {
     /// discord section


### PR DESCRIPTION
#### 🐛 Issue description

When start the discord bot with a configuration file in combinaison with command line argument, application crash if the configuration is not fully set with all section completed. If you want for exemple add configuration for only the faucet part but  give the discord token and guild id in cli, the bot doesn't start.

```
./discord_bot start -g <GUILD_ID> -t <TOKEN> -c config.toml
error: discord_bot fatal error: parse error: missing field `discord` at line 18 column 1
```

#### ✅ Resolution 

To fix that, only [configure serde](https://serde.rs/container-attrs.html#default) to fill configuration section with default value if field is not set on toml file on deserialization.

Sorry the PR description is much longer than the fix :😛. 
