### PR TITLE
ci(publish): fix dockerhub description warning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_HUB_REGISTRY_ID }}
-          description: Docker image for https://github.com/${{ github.repository }}
+          short-description: Docker image for https://github.com/${{ github.repository }}
           password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
           repository: ${{ github.repository }}
           readme-filepath: README.md


### PR DESCRIPTION
This PR fixes a warning in the publish action.

The current publish action failed because, so far, dockerhub image doesn't exist. So, as there's no modification on the readme, merging this PR will make lights turn green again.

We could then improve the readme (mentioning the config file) after the 1st release to have a nice dockerhub page :smiley: 