### PR TITLE
🚦Allow sharding configuration

### DIFF
--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -80,13 +80,18 @@ impl config::Override<DiscordBotConfig> for StartCmd {
             config.discord.guild_id = guild_id
         }
 
-        if let (Some(shard), Some(shards)) = (self.shard, self.shards) {
-            config.discord.sharding = DiscordShardingSection { shard, shards }
-        } else if let (None, Some(shards)) = (self.shard, self.shards) {
-            return Err(FrameworkError::from(FrameworkErrorKind::ConfigError.context(format!("❌ When set the `shards` ({}) attribute, you should also set the `shard` index", shards))));
-        } else if let (Some(shard), None) = (self.shard, self.shards) {
-            return Err(FrameworkError::from(FrameworkErrorKind::ConfigError.context(format!("❌ When set the `shard` ({}) index, you should also set the total number of `shards` (`--shards <NUMBER_OF_SHARD>`)", shard))));
-        }
+        match (self.shard, self.shards) {
+            (Some(shard), Some(shards)) => {
+                config.discord.sharding = DiscordShardingSection { shard, shards }
+            }
+            (None, Some(shards)) => {
+                Err(FrameworkError::from(FrameworkErrorKind::ConfigError.context(format!("❌ When set the `shards` ({}) attribute, you should also set the `shard` index", shards))))?;
+            }
+            (Some(shard), None) => {
+                Err(FrameworkError::from(FrameworkErrorKind::ConfigError.context(format!("❌ When set the `shard` ({}) index, you should also set the total number of `shards` (`--shards <NUMBER_OF_SHARD>`)", shard))))?;
+            }
+            _ => (),
+        };
 
         if self.prometheus_endpoint.is_some() {
             config.metrics.endpoint = self.prometheus_endpoint

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -34,7 +34,7 @@ impl Runnable for StartCmd {
         let config = APP.config();
 
         abscissa_tokio::run(&APP, async {
-            match client::start(&config.discord.token, config.discord.guild_id).await {
+            match client::start(&config.discord.token, config.discord.guild_id, config.discord.sharding.shard, config.discord.sharding.shards).await {
                 Err(why) => error!("💀 Client error: {:?}", why),
                 _ => info!("👋 Bye!"),
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct DiscordBotConfig {
 
 /// Discord section.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct DiscordSection {
     /// Token
     pub token: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct DiscordSection {
 
     /// Guild ID (Server ID)
     pub guild_id: u64,
+
+    /// Configure the sharding strategy for this process
+    pub sharding: DiscordShardingSection,
 }
 
 impl Default for DiscordSection {
@@ -37,6 +40,26 @@ impl Default for DiscordSection {
         Self {
             token: "".to_owned(),
             guild_id: 0,
+            sharding: DiscordShardingSection::default(),
+        }
+    }
+}
+
+/// Sharding strategy configuration
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscordShardingSection {
+    /// Shard index (default 0)
+    pub shard: u64,
+    /// Number of total shards (default 1)
+    pub shards: u64,
+}
+
+impl Default for DiscordShardingSection {
+    fn default() -> Self {
+        Self {
+            shard: 0,
+            shards: 1,
         }
     }
 }

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -208,7 +208,7 @@ fn register_metrics() {
 }
 
 /// Start the discord bot (given a token)
-pub async fn start(token: &str, guild_id: u64) -> Result<(), Error> {
+pub async fn start(token: &str, guild_id: u64, shard: u64, shards: u64) -> Result<(), Error> {
     register_metrics();
 
     let intents = GatewayIntents::empty();
@@ -239,7 +239,7 @@ pub async fn start(token: &str, guild_id: u64) -> Result<(), Error> {
     };
 
     match result {
-        Ok(mut client) => client.start().await.map_err(Error::from),
+        Ok(mut client) => client.start_shard(shard, shards).await.map_err(Error::from),
         r => r.map(|_| ()),
     }
 }


### PR DESCRIPTION
#### 📝 Allow configure the sharding

Serenity library allow [configure sharding](https://docs.rs/serenity/latest/serenity/client/struct.Client.html#method.start_shard) on discord bot to handle mass user interactions. This PR add some parameters in the configuration file and CLI args allowing user to start multiple instance of this discord bot. 

#### ⚙️ Usage 

This configuration file will start the 2nd shard (index 1) of 2 shards. 
```
[discord.sharding]
shard = 1
shards = 2
```

You could also give sharding configuration through CLI args : 
```
Boot the discord bot

USAGE:
    discord_bot start [OPTIONS]

OPTIONS:
    -g, --guild-id <GUILD_ID>
            The guild ID (Server ID)

    -h, --help
            Print help information

    -p, --prometheus-endpoint <PROMETHEUS_ENDPOINT>
            The prometheus endpoint. Optional. Configures an HTTP exporter that functions as a
            scrape endpoint for prometheus. The value is an IPv4 or IPv6 address and a port number,
            separated by a colon. For instance: 0.0.0.0:9000

        --shard <SHARD>
            The shard index ID to start. Establish a sharded connection and start listening for
            events. This will start receiving events and dispatch them to your registered handlers.
            This will create a single shard by ID. If using one shard per process, you will need to
            start other bot process with the other shard IDs

        --shards <SHARDS>
            The total numbers of shards in the sharding connection

    -t, --token <TOKEN>
            The discord token
```