### PR TITLE
📨 Generic transaction discord messages

### DIFF
--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -9,6 +9,7 @@ use cosmrs::tx::Fee;
 use cosmrs::{bank::MsgSend, Coin};
 use tracing::{error, info};
 
+use crate::discord::discord_client::message::FaucetTransactionMessage;
 use crate::{
     cli::{
         config::{DiscordBotConfig, DiscordShardingSection},
@@ -70,7 +71,7 @@ impl Runnable for StartCmd {
                 .unwrap()
                 .start();
 
-            let addr_tx_handler = TxHandler::<MsgSend>::new(
+            let addr_tx_handler = TxHandler::<MsgSend, FaucetTransactionMessage>::new(
                 config.chain.chain_id.to_string(),
                 sender.to_owned(),
                 config.faucet.memo.to_string(),

--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -9,7 +9,7 @@ use cosmrs::tx::Fee;
 use cosmrs::{bank::MsgSend, Coin};
 use tracing::{error, info};
 
-use crate::discord::discord_client::message::FaucetTransactionMessage;
+use crate::cosmos::faucet::discord_message::FaucetTransactionMessage;
 use crate::{
     cli::{
         config::{DiscordBotConfig, DiscordShardingSection},

--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -85,7 +85,7 @@ impl Runnable for StartCmd {
                     granter: None,
                 },
                 config.chain.batch_transaction_window,
-                Some(config.faucet.channel_id),
+                config.faucet.channel_id,
                 Actors {
                     grpc_client: addr_cosmos_client.clone(),
                     discord_client: addr_discord_client.clone(),

--- a/src/cosmos/faucet/discord_message.rs
+++ b/src/cosmos/faucet/discord_message.rs
@@ -1,0 +1,109 @@
+//! Implementation of a faucet discord message result for after transaction
+
+use crate::cosmos::tx::discord_message::TransactionDiscordMessage;
+use crate::cosmos::tx::error::Error as TxError;
+use crate::discord::discord_client::message::DiscordMessage;
+use cosmos_sdk_proto::cosmos::base::abci::v1beta1::TxResponse;
+use serenity::async_trait;
+use serenity::http::Http;
+use serenity::model::channel::Message;
+use serenity::model::id::ChannelId;
+use serenity::model::user::User;
+use serenity::prelude::Mentionable;
+use serenity::Error;
+use tracing::{error, info};
+
+/// The faucet respons emessage when transaction successful
+#[derive(Clone, Debug)]
+pub struct FaucetTransactionMessage {
+    /// Title of the embedded message - optional
+    pub title: String,
+    /// Description of the embedded message - optional
+    pub description: String,
+    /// Content of the message body - optional
+    pub content: String,
+    /// Channel to send into
+    pub channel_id: u64,
+}
+
+impl TransactionDiscordMessage for FaucetTransactionMessage {
+    fn build_message(
+        tx_response: Result<TxResponse, TxError>,
+        subscribers: Vec<User>,
+        channel_id: u64,
+    ) -> Self {
+        match tx_response {
+            Ok(tx_response) => {
+                info!(
+                    "✅ Transaction successfully broadcasted : {}",
+                    tx_response.txhash
+                );
+                Self {
+                    title: String::from("🚀 Transaction broadcasted!"),
+                    description: format!(
+                        "\t- 🤝 Transaction hash: {}
+                            \t- ⚙️ Result code : {}
+                            \t- ⛽️ Gas used: {}",
+                        tx_response.txhash, tx_response.code, tx_response.gas_used
+                    ),
+                    content: {
+                        let mut str = String::new();
+                        for sub in subscribers {
+                            str.push_str(
+                                &format_args!("{member} ", member = &sub.mention()).to_string(),
+                            );
+                        }
+                        str
+                    },
+                    channel_id,
+                }
+            }
+            Err(why) => {
+                error!("❌ Failed broadcast transaction {}", why);
+                Self {
+                    title: String::from("🤷 So sorry, something went wrong"),
+                    description: String::from(
+                        "You're request was not processed.\nThe transaction was not broadcasted.",
+                    ),
+                    content: {
+                        let mut str = String::new();
+                        for sub in subscribers {
+                            str.push_str(
+                                &format_args!("{member} ", member = &sub.mention()).to_string(),
+                            );
+                        }
+                        str
+                    },
+                    channel_id,
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl DiscordMessage for FaucetTransactionMessage {
+    fn channel_id(&self) -> u64 {
+        self.channel_id
+    }
+
+    async fn send_message(self, http: &Http) -> Result<Message, Error> {
+        ChannelId(self.channel_id)
+            .send_message(&http, |m| {
+                m.content(self.content).tts(true);
+                if !self.title.is_empty() || !self.description.is_empty() {
+                    m.embed(|e| {
+                        if !self.title.is_empty() {
+                            e.title(self.title);
+                        }
+                        if !self.description.is_empty() {
+                            e.description(self.description);
+                        }
+                        e
+                    });
+                }
+                m
+            })
+            .await
+    }
+}

--- a/src/cosmos/faucet/mod.rs
+++ b/src/cosmos/faucet/mod.rs
@@ -5,6 +5,7 @@ mod handlers;
 pub mod messages;
 
 use crate::cosmos::tx::TxHandler;
+use crate::discord::discord_client::message::FaucetTransactionMessage;
 use actix::Addr;
 use cosmrs::bank::MsgSend;
 use cosmrs::{AccountId, Coin};
@@ -16,5 +17,5 @@ pub struct Faucet {
     /// Transaction amount
     pub amount: Coin,
     /// Transaction handler client address to send transaction
-    pub tx_handler: Addr<TxHandler<MsgSend>>,
+    pub tx_handler: Addr<TxHandler<MsgSend, FaucetTransactionMessage>>,
 }

--- a/src/cosmos/faucet/mod.rs
+++ b/src/cosmos/faucet/mod.rs
@@ -1,11 +1,12 @@
 //! Holds all the faucet actor configuration
 
 mod actor;
+pub mod discord_message;
 mod handlers;
 pub mod messages;
 
+use crate::cosmos::faucet::discord_message::FaucetTransactionMessage;
 use crate::cosmos::tx::TxHandler;
-use crate::discord::discord_client::message::FaucetTransactionMessage;
 use actix::Addr;
 use cosmrs::bank::MsgSend;
 use cosmrs::{AccountId, Coin};

--- a/src/cosmos/tx/actor.rs
+++ b/src/cosmos/tx/actor.rs
@@ -1,12 +1,14 @@
 use crate::cosmos::tx::messages::trigger::TriggerTx;
 use crate::cosmos::tx::TxHandler;
+use crate::discord::discord_client::message::{DiscordMessage, TransactionMessage};
 use actix::{Actor, AsyncContext, Context};
 use cosmrs::tx::Msg;
 use tracing::info;
 
-impl<T> Actor for TxHandler<T>
+impl<T, M> Actor for TxHandler<T, M>
 where
     T: Msg + Unpin + 'static,
+    M: TransactionMessage + DiscordMessage + Unpin + Send + 'static,
 {
     type Context = Context<Self>;
 

--- a/src/cosmos/tx/actor.rs
+++ b/src/cosmos/tx/actor.rs
@@ -1,6 +1,7 @@
+use crate::cosmos::tx::discord_message::TransactionDiscordMessage;
 use crate::cosmos::tx::messages::trigger::TriggerTx;
 use crate::cosmos::tx::TxHandler;
-use crate::discord::discord_client::message::{DiscordMessage, TransactionMessage};
+use crate::discord::discord_client::message::DiscordMessage;
 use actix::{Actor, AsyncContext, Context};
 use cosmrs::tx::Msg;
 use tracing::info;
@@ -8,7 +9,7 @@ use tracing::info;
 impl<T, M> Actor for TxHandler<T, M>
 where
     T: Msg + Unpin + 'static,
-    M: TransactionMessage + DiscordMessage + Unpin + Send + 'static,
+    M: TransactionDiscordMessage + DiscordMessage + Unpin + Send + 'static,
 {
     type Context = Context<Self>;
 

--- a/src/cosmos/tx/discord_message.rs
+++ b/src/cosmos/tx/discord_message.rs
@@ -1,0 +1,15 @@
+//! Define trait for all transaction result message
+
+use crate::cosmos::tx::error::Error as TxError;
+use cosmos_sdk_proto::cosmos::base::abci::v1beta1::TxResponse;
+use serenity::model::user::User;
+
+/// Trait for all transaction discord message
+pub trait TransactionDiscordMessage {
+    /// Build the message with the transaction response or failure error
+    fn build_message(
+        tx_response: Result<TxResponse, TxError>,
+        subscribers: Vec<User>,
+        channel_id: u64,
+    ) -> Self;
+}

--- a/src/cosmos/tx/handlers/register.rs
+++ b/src/cosmos/tx/handlers/register.rs
@@ -2,12 +2,14 @@
 
 use crate::cosmos::tx::messages::register::{RegisterMsg, RegisterMsgResult};
 use crate::cosmos::tx::TxHandler;
+use crate::discord::discord_client::message::{DiscordMessage, TransactionMessage};
 use actix::Handler;
 use cosmrs::tx::Msg;
 
-impl<T> Handler<RegisterMsg<T>> for TxHandler<T>
+impl<T, M> Handler<RegisterMsg<T>> for TxHandler<T, M>
 where
     T: Msg + Unpin + 'static,
+    M: TransactionMessage + DiscordMessage + Unpin + Send + 'static,
 {
     type Result = RegisterMsgResult;
 

--- a/src/cosmos/tx/handlers/register.rs
+++ b/src/cosmos/tx/handlers/register.rs
@@ -1,15 +1,16 @@
 //! Register transaction handler
 
+use crate::cosmos::tx::discord_message::TransactionDiscordMessage;
 use crate::cosmos::tx::messages::register::{RegisterMsg, RegisterMsgResult};
 use crate::cosmos::tx::TxHandler;
-use crate::discord::discord_client::message::{DiscordMessage, TransactionMessage};
+use crate::discord::discord_client::message::DiscordMessage;
 use actix::Handler;
 use cosmrs::tx::Msg;
 
 impl<T, M> Handler<RegisterMsg<T>> for TxHandler<T, M>
 where
     T: Msg + Unpin + 'static,
-    M: TransactionMessage + DiscordMessage + Unpin + Send + 'static,
+    M: TransactionDiscordMessage + DiscordMessage + Unpin + Send + 'static,
 {
     type Result = RegisterMsgResult;
 

--- a/src/cosmos/tx/handlers/trigger.rs
+++ b/src/cosmos/tx/handlers/trigger.rs
@@ -83,7 +83,7 @@ where
                 let discord_message = M::build_message(
                     tx_result.and_then(|i| i.map_err(Error::from)),
                     subscribers,
-                    act.channel_id.unwrap(),
+                    act.channel_id,
                 );
                 discord_client.do_send(SendMessage {
                     message: discord_message,

--- a/src/cosmos/tx/handlers/trigger.rs
+++ b/src/cosmos/tx/handlers/trigger.rs
@@ -2,10 +2,11 @@
 
 use crate::cosmos::client::messages::broadcast_tx::{BroadcastTx, BroadcastTxResult};
 use crate::cosmos::client::messages::get_account::{GetAccount, GetAccountResult};
+use crate::cosmos::tx::discord_message::TransactionDiscordMessage;
 use crate::cosmos::tx::error::Error;
 use crate::cosmos::tx::messages::trigger::{TriggerTx, TriggerTxResult};
 use crate::cosmos::tx::TxHandler;
-use crate::discord::discord_client::message::{DiscordMessage, TransactionMessage};
+use crate::discord::discord_client::message::DiscordMessage;
 use crate::discord::discord_client::messages::send_msg::SendMessage;
 use actix::{ActorFutureExt, Handler, MailboxError, ResponseActFuture, WrapFuture};
 use cosmrs::tx::{Body, Msg};
@@ -15,7 +16,7 @@ use tracing::log::error;
 impl<T, M> Handler<TriggerTx> for TxHandler<T, M>
 where
     T: Msg + Unpin + 'static,
-    M: TransactionMessage + DiscordMessage + Unpin + Send + 'static,
+    M: TransactionDiscordMessage + DiscordMessage + Unpin + Send + 'static,
 {
     type Result = ResponseActFuture<Self, TriggerTxResult>;
 

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -1,14 +1,16 @@
 //! Holds Tx actors.
 
 mod actor;
+pub mod discord_message;
 pub mod error;
 pub mod handlers;
 pub mod messages;
 
 use crate::cosmos::client::account::Account;
 use crate::cosmos::client::Client;
+use crate::cosmos::tx::discord_message::TransactionDiscordMessage;
 use crate::cosmos::tx::error::Error;
-use crate::discord::discord_client::message::{DiscordMessage, TransactionMessage};
+use crate::discord::discord_client::message::DiscordMessage;
 use crate::discord::discord_client::DiscordActor;
 use actix::Addr;
 use cosmos_sdk_proto::cosmos::auth::v1beta1::BaseAccount;
@@ -20,7 +22,7 @@ use tonic::transport::Channel;
 /// Contains addresses of actors that will be used by the TxHandler
 pub struct Actors<M>
 where
-    M: TransactionMessage + DiscordMessage + Unpin + 'static,
+    M: TransactionDiscordMessage + DiscordMessage + Unpin + 'static,
 {
     /// GRPC client to send transaction.
     pub grpc_client: Addr<Client<Channel>>,
@@ -33,7 +35,7 @@ where
 pub struct TxHandler<T, M>
 where
     T: Msg + Unpin,
-    M: TransactionMessage + DiscordMessage + Unpin + 'static,
+    M: TransactionDiscordMessage + DiscordMessage + Unpin + 'static,
 {
     /// Cosmos chain id.
     pub chain_id: String,
@@ -60,7 +62,7 @@ where
 impl<T, M> TxHandler<T, M>
 where
     T: Msg + Unpin + 'static,
-    M: TransactionMessage + Unpin + DiscordMessage,
+    M: TransactionDiscordMessage + Unpin + DiscordMessage,
 {
     /// Create a new TxHandler for a specific message type.
     pub fn new(

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -6,7 +6,6 @@ pub mod error;
 pub mod handlers;
 pub mod messages;
 
-use std::marker::PhantomData;
 use crate::cosmos::client::account::Account;
 use crate::cosmos::client::Client;
 use crate::cosmos::tx::discord_message::TransactionDiscordMessage;
@@ -17,12 +16,12 @@ use actix::Addr;
 use cosmos_sdk_proto::cosmos::auth::v1beta1::BaseAccount;
 use cosmrs::tx::{Body, Fee, Msg, SignDoc, SignerInfo};
 use serenity::model::user::User;
+use std::marker::PhantomData;
 use std::time::Duration;
 use tonic::transport::Channel;
 
 /// Contains addresses of actors that will be used by the TxHandler
-pub struct Actors
-{
+pub struct Actors {
     /// GRPC client to send transaction.
     pub grpc_client: Addr<Client<Channel>>,
     /// Address of the Discord client Actor
@@ -47,7 +46,7 @@ where
     /// Duration between two transactions.
     pub batch_window: Duration,
     /// Set the discord channel where to send transaction result.
-    pub channel_id: Option<u64>,
+    pub channel_id: u64,
     /// Contains the batch of transaction message to sent as prost::Any.
     msgs: Vec<T>,
     /// Contains the list of all user that request transaction.
@@ -59,7 +58,7 @@ where
     /// To tell compiler that the message type is of type M and to avoid unused generic parameter compilation error.
     /// This is mandatory if we would like to instantiate the message with it's static method `::build_message`.
     /// See [E0392](https://doc.rust-lang.org/error-index.html#E0392) for more detail of usage of PhantomData.
-    phantom: PhantomData<M>
+    phantom: PhantomData<M>,
 }
 
 impl<T, M> TxHandler<T, M>
@@ -74,7 +73,7 @@ where
         memo: String,
         fee: Fee,
         batch_window: Duration,
-        channel_id: Option<u64>,
+        channel_id: u64,
         actors: Actors,
     ) -> TxHandler<T, M> {
         Self {
@@ -88,7 +87,7 @@ where
             subscribers: vec![],
             grpc_client: actors.grpc_client,
             discord_client: actors.discord_client,
-            phantom: PhantomData
+            phantom: PhantomData,
         }
     }
 

--- a/src/discord/discord_client/actor.rs
+++ b/src/discord/discord_client/actor.rs
@@ -1,7 +1,11 @@
+use crate::discord::discord_client::message::DiscordMessage;
 use actix::{Actor, Context};
 
 use super::DiscordActor;
 
-impl Actor for DiscordActor {
+impl<M> Actor for DiscordActor<M>
+where
+    M: DiscordMessage + Unpin + 'static,
+{
     type Context = Context<Self>;
 }

--- a/src/discord/discord_client/actor.rs
+++ b/src/discord/discord_client/actor.rs
@@ -1,11 +1,8 @@
-use crate::discord::discord_client::message::DiscordMessage;
 use actix::{Actor, Context};
 
 use super::DiscordActor;
 
-impl<M> Actor for DiscordActor<M>
-where
-    M: DiscordMessage + Unpin + 'static,
+impl Actor for DiscordActor
 {
     type Context = Context<Self>;
 }

--- a/src/discord/discord_client/actor.rs
+++ b/src/discord/discord_client/actor.rs
@@ -2,7 +2,6 @@ use actix::{Actor, Context};
 
 use super::DiscordActor;
 
-impl Actor for DiscordActor
-{
+impl Actor for DiscordActor {
     type Context = Context<Self>;
 }

--- a/src/discord/discord_client/handlers/send_msg.rs
+++ b/src/discord/discord_client/handlers/send_msg.rs
@@ -1,40 +1,30 @@
 use actix::{ContextFutureSpawner, Handler, WrapFuture};
-use serenity::{http::Http, model::id::ChannelId};
+use serenity::http::Http;
 use tracing::log::{info, warn};
 
+use crate::discord::discord_client::message::DiscordMessage;
 use crate::discord::discord_client::{
     messages::send_msg::{SendMessage, SendMessageResult},
     DiscordActor,
 };
 
-impl Handler<SendMessage> for DiscordActor {
+impl<M> Handler<SendMessage<M>> for DiscordActor<M>
+where
+    M: DiscordMessage + Unpin + 'static,
+{
     type Result = SendMessageResult;
 
-    fn handle(&mut self, msg: SendMessage, ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: SendMessage<M>, ctx: &mut Self::Context) -> Self::Result {
         let http = Http::new(&self.token);
 
         async move {
             info!(
-                "✉️ Sending message {} to channel with ID {}",
-                msg.content.clone(),
-                msg.channel_id
+                "✉️ Sending message to channel with ID {}",
+                msg.message.channel_id()
             );
-            let _ = ChannelId(msg.channel_id)
-                .send_message(&http, |m| {
-                    m.content(msg.content).tts(true);
-                    if !msg.title.is_empty() || !msg.description.is_empty() {
-                        m.embed(|e| {
-                            if !msg.title.is_empty() {
-                                e.title(msg.title);
-                            }
-                            if !msg.description.is_empty() {
-                                e.description(msg.description);
-                            }
-                            e
-                        });
-                    }
-                    m
-                })
+            let _ = msg
+                .message
+                .send_message(&http)
                 .await
                 .map_err(|err| warn!("Cannot send message: {:?}", err));
         }

--- a/src/discord/discord_client/handlers/send_msg.rs
+++ b/src/discord/discord_client/handlers/send_msg.rs
@@ -8,7 +8,7 @@ use crate::discord::discord_client::{
     DiscordActor,
 };
 
-impl<M> Handler<SendMessage<M>> for DiscordActor<M>
+impl<M> Handler<SendMessage<M>> for DiscordActor
 where
     M: DiscordMessage + Unpin + 'static,
 {

--- a/src/discord/discord_client/message.rs
+++ b/src/discord/discord_client/message.rs
@@ -1,0 +1,126 @@
+//! Contains definition of a discord message
+
+use crate::cosmos::tx::error::Error as TxError;
+use cosmos_sdk_proto::cosmos::base::abci::v1beta1::TxResponse;
+use serenity::async_trait;
+use serenity::http::Http;
+use serenity::model::channel::Message;
+use serenity::model::id::ChannelId;
+use serenity::model::user::User;
+use serenity::prelude::Mentionable;
+use serenity::Error;
+use tracing::{error, info};
+
+/// Trait representing a disorcd message
+#[async_trait]
+pub trait DiscordMessage {
+    /// Return the channel id relative to send discord message.
+    fn channel_id(&self) -> u64;
+    /// Send the message to discord
+    async fn send_message(self, http: &Http) -> Result<Message, Error>;
+}
+
+/// Trait for all transaction discord message
+pub trait TransactionMessage {
+    /// Build the message with the transaction response or failure error
+    fn build_message(
+        tx_response: Result<TxResponse, TxError>,
+        subscribers: Vec<User>,
+        channel_id: u64,
+    ) -> Self;
+}
+
+/// The faucet respons emessage when transaction successful
+#[derive(Clone, Debug)]
+pub struct FaucetTransactionMessage {
+    /// Title of the embedded message - optional
+    pub title: String,
+    /// Description of the embedded message - optional
+    pub description: String,
+    /// Content of the message body - optional
+    pub content: String,
+    /// Channel to send into
+    pub channel_id: u64,
+}
+
+impl TransactionMessage for FaucetTransactionMessage {
+    fn build_message(
+        tx_response: Result<TxResponse, TxError>,
+        subscribers: Vec<User>,
+        channel_id: u64,
+    ) -> Self {
+        match tx_response {
+            Ok(tx_response) => {
+                info!(
+                    "✅ Transaction successfully broadcasted : {}",
+                    tx_response.txhash
+                );
+                Self {
+                    title: String::from("🚀 Transaction broadcasted!"),
+                    description: format!(
+                        "\t- 🤝 Transaction hash: {}
+                            \t- ⚙️ Result code : {}
+                            \t- ⛽️ Gas used: {}",
+                        tx_response.txhash, tx_response.code, tx_response.gas_used
+                    ),
+                    content: {
+                        let mut str = String::new();
+                        for sub in subscribers {
+                            str.push_str(
+                                &format_args!("{member} ", member = &sub.mention()).to_string(),
+                            );
+                        }
+                        str
+                    },
+                    channel_id: channel_id,
+                }
+            }
+            Err(why) => {
+                error!("❌ Failed broadcast transaction {}", why);
+                Self {
+                    title: String::from("🤷 So sorry, something went wrong"),
+                    description: String::from(
+                        "You're request was not processed.\nThe transaction was not broadcasted.",
+                    ),
+                    content: {
+                        let mut str = String::new();
+                        for sub in subscribers {
+                            str.push_str(
+                                &format_args!("{member} ", member = &sub.mention()).to_string(),
+                            );
+                        }
+                        str
+                    },
+                    channel_id,
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl DiscordMessage for FaucetTransactionMessage {
+    fn channel_id(&self) -> u64 {
+        self.channel_id
+    }
+
+    async fn send_message(self, http: &Http) -> Result<Message, Error> {
+        ChannelId(self.channel_id)
+            .send_message(&http, |m| {
+                m.content(self.content).tts(true);
+                if !self.title.is_empty() || !self.description.is_empty() {
+                    m.embed(|e| {
+                        if !self.title.is_empty() {
+                            e.title(self.title);
+                        }
+                        if !self.description.is_empty() {
+                            e.description(self.description);
+                        }
+                        e
+                    });
+                }
+                m
+            })
+            .await
+    }
+}

--- a/src/discord/discord_client/message.rs
+++ b/src/discord/discord_client/message.rs
@@ -1,15 +1,9 @@
 //! Contains definition of a discord message
 
-use crate::cosmos::tx::error::Error as TxError;
-use cosmos_sdk_proto::cosmos::base::abci::v1beta1::TxResponse;
 use serenity::async_trait;
 use serenity::http::Http;
 use serenity::model::channel::Message;
-use serenity::model::id::ChannelId;
-use serenity::model::user::User;
-use serenity::prelude::Mentionable;
 use serenity::Error;
-use tracing::{error, info};
 
 /// Trait representing a disorcd message
 #[async_trait]
@@ -18,109 +12,4 @@ pub trait DiscordMessage {
     fn channel_id(&self) -> u64;
     /// Send the message to discord
     async fn send_message(self, http: &Http) -> Result<Message, Error>;
-}
-
-/// Trait for all transaction discord message
-pub trait TransactionMessage {
-    /// Build the message with the transaction response or failure error
-    fn build_message(
-        tx_response: Result<TxResponse, TxError>,
-        subscribers: Vec<User>,
-        channel_id: u64,
-    ) -> Self;
-}
-
-/// The faucet respons emessage when transaction successful
-#[derive(Clone, Debug)]
-pub struct FaucetTransactionMessage {
-    /// Title of the embedded message - optional
-    pub title: String,
-    /// Description of the embedded message - optional
-    pub description: String,
-    /// Content of the message body - optional
-    pub content: String,
-    /// Channel to send into
-    pub channel_id: u64,
-}
-
-impl TransactionMessage for FaucetTransactionMessage {
-    fn build_message(
-        tx_response: Result<TxResponse, TxError>,
-        subscribers: Vec<User>,
-        channel_id: u64,
-    ) -> Self {
-        match tx_response {
-            Ok(tx_response) => {
-                info!(
-                    "✅ Transaction successfully broadcasted : {}",
-                    tx_response.txhash
-                );
-                Self {
-                    title: String::from("🚀 Transaction broadcasted!"),
-                    description: format!(
-                        "\t- 🤝 Transaction hash: {}
-                            \t- ⚙️ Result code : {}
-                            \t- ⛽️ Gas used: {}",
-                        tx_response.txhash, tx_response.code, tx_response.gas_used
-                    ),
-                    content: {
-                        let mut str = String::new();
-                        for sub in subscribers {
-                            str.push_str(
-                                &format_args!("{member} ", member = &sub.mention()).to_string(),
-                            );
-                        }
-                        str
-                    },
-                    channel_id: channel_id,
-                }
-            }
-            Err(why) => {
-                error!("❌ Failed broadcast transaction {}", why);
-                Self {
-                    title: String::from("🤷 So sorry, something went wrong"),
-                    description: String::from(
-                        "You're request was not processed.\nThe transaction was not broadcasted.",
-                    ),
-                    content: {
-                        let mut str = String::new();
-                        for sub in subscribers {
-                            str.push_str(
-                                &format_args!("{member} ", member = &sub.mention()).to_string(),
-                            );
-                        }
-                        str
-                    },
-                    channel_id,
-                }
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl DiscordMessage for FaucetTransactionMessage {
-    fn channel_id(&self) -> u64 {
-        self.channel_id
-    }
-
-    async fn send_message(self, http: &Http) -> Result<Message, Error> {
-        ChannelId(self.channel_id)
-            .send_message(&http, |m| {
-                m.content(self.content).tts(true);
-                if !self.title.is_empty() || !self.description.is_empty() {
-                    m.embed(|e| {
-                        if !self.title.is_empty() {
-                            e.title(self.title);
-                        }
-                        if !self.description.is_empty() {
-                            e.description(self.description);
-                        }
-                        e
-                    });
-                }
-                m
-            })
-            .await
-    }
 }

--- a/src/discord/discord_client/messages/send_msg.rs
+++ b/src/discord/discord_client/messages/send_msg.rs
@@ -1,5 +1,6 @@
 //! Holds discord send message related types
 
+use crate::discord::discord_client::message::DiscordMessage;
 use actix::Message;
 
 /// Result of a discord message actor message
@@ -8,13 +9,10 @@ pub type SendMessageResult = ();
 /// Send discord message actor message
 #[derive(Message)]
 #[rtype(result = "SendMessageResult")]
-pub struct SendMessage {
-    /// Title of the embedded message - optional
-    pub title: String,
-    /// Description of the embedded message - optional
-    pub description: String,
-    /// Content of the message body - optional
-    pub content: String,
-    /// Channel to send into
-    pub channel_id: u64,
+pub struct SendMessage<M>
+where
+    M: DiscordMessage,
+{
+    /// Message to send to discord
+    pub message: M,
 }

--- a/src/discord/discord_client/mod.rs
+++ b/src/discord/discord_client/mod.rs
@@ -1,31 +1,22 @@
 //! Lite Discord Actor Client
 
-use crate::discord::discord_client::message::DiscordMessage;
-use std::marker::PhantomData;
-
 mod actor;
 mod handlers;
 pub mod message;
 pub mod messages;
 
 /// Discord actor client
-pub struct DiscordActor<M>
-where
-    M: DiscordMessage,
+pub struct DiscordActor
 {
     token: String,
-    phantom: PhantomData<M>,
 }
 
-impl<M> DiscordActor<M>
-where
-    M: DiscordMessage,
+impl DiscordActor
 {
     /// Create a new discord actor client
     pub fn new(token: String) -> Self {
         DiscordActor {
-            token,
-            phantom: PhantomData,
+            token
         }
     }
 }

--- a/src/discord/discord_client/mod.rs
+++ b/src/discord/discord_client/mod.rs
@@ -1,17 +1,31 @@
 //! Lite Discord Actor Client
 
+use crate::discord::discord_client::message::DiscordMessage;
+use std::marker::PhantomData;
+
 mod actor;
 mod handlers;
+pub mod message;
 pub mod messages;
 
 /// Discord actor client
-pub struct DiscordActor {
+pub struct DiscordActor<M>
+where
+    M: DiscordMessage,
+{
     token: String,
+    phantom: PhantomData<M>,
 }
 
-impl DiscordActor {
+impl<M> DiscordActor<M>
+where
+    M: DiscordMessage,
+{
     /// Create a new discord actor client
     pub fn new(token: String) -> Self {
-        DiscordActor { token }
+        DiscordActor {
+            token,
+            phantom: PhantomData,
+        }
     }
 }

--- a/src/discord/discord_client/mod.rs
+++ b/src/discord/discord_client/mod.rs
@@ -6,17 +6,13 @@ pub mod message;
 pub mod messages;
 
 /// Discord actor client
-pub struct DiscordActor
-{
+pub struct DiscordActor {
     token: String,
 }
 
-impl DiscordActor
-{
+impl DiscordActor {
     /// Create a new discord actor client
     pub fn new(token: String) -> Self {
-        DiscordActor {
-            token
-        }
+        DiscordActor { token }
     }
 }

--- a/src/discord/discord_server/mod.rs
+++ b/src/discord/discord_server/mod.rs
@@ -30,7 +30,7 @@ use std::str::FromStr;
 use std::time::Instant;
 use tonic::transport::Channel;
 
-use crate::discord::discord_client::message::FaucetTransactionMessage;
+use crate::cosmos::faucet::discord_message::FaucetTransactionMessage;
 use tracing::{debug, error, info, warn};
 
 pub mod cmd;

--- a/src/discord/discord_server/mod.rs
+++ b/src/discord/discord_server/mod.rs
@@ -30,6 +30,7 @@ use std::str::FromStr;
 use std::time::Instant;
 use tonic::transport::Channel;
 
+use crate::discord::discord_client::message::FaucetTransactionMessage;
 use tracing::{debug, error, info, warn};
 
 pub mod cmd;
@@ -41,7 +42,7 @@ pub mod utils;
 #[derive(Clone)]
 pub struct Actors {
     /// Cosmos transaction handler actor address
-    pub tx_handler: Addr<TxHandler<MsgSend>>,
+    pub tx_handler: Addr<TxHandler<MsgSend, FaucetTransactionMessage>>,
     /// Cosmos client actor address
     pub cosmos_client: Addr<crate::cosmos::client::Client<Channel>>,
     /// Cosmos faucet actor address


### PR DESCRIPTION
**⚠️ CHANGE BASE BRANCH BEFORE MERGE: Waiting #42** 

#### 📝 Description
This PR is an improvement of the transaction handler to avoid send the same message on discord on different transaction type.

#### 🏗 Architecture

- `SendMessage` actor message has been modified the get a generic of type `Message` trait. Message trait is responsible of call the discord library to send the message. 
- `TxHandler` now hold a generic of type `TransactionMessage` trait that should impl `Message` trait. 
- `TransactionMessage` trait allow to generate the message to send to discord based on the transaction result and subscribers. 

