### PR TITLE
ci(release): properly configure conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
             @semantic-release/exec
             @semantic-release/git
             @google/semantic-release-replace-plugin
+          extends: |
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -2,8 +2,10 @@ branches:
   - main
 
 plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
       changelogTitle: "# ØKP4 template-rust"


### PR DESCRIPTION
Use the `conventionalcommits` preset of semantic release.