### PR TITLE
🔑 Allow setting mnemonic in command arg

### DIFF
--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -33,6 +33,10 @@ pub struct StartCmd {
     #[clap(short = 'g', long = "guild-id")]
     guild_id: Option<u64>,
 
+    /// Configure the faucet mnemonic in order to send to token from this address.
+    #[clap(short = 'm', long = "mnemonic")]
+    mnemonic: Option<String>,
+
     /// The shard index ID to start.
     /// Establish a sharded connection and start listening for events.
     /// This will start receiving events and dispatch them to your registered handlers.
@@ -140,6 +144,10 @@ impl config::Override<DiscordBotConfig> for StartCmd {
 
         if let Some(guild_id) = self.guild_id {
             config.discord.guild_id = guild_id
+        }
+
+        if let Some(mnemonic) = self.mnemonic.clone() {
+            config.faucet.mnemonic = mnemonic
         }
 
         match (self.shard, self.shards) {

--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -33,7 +33,7 @@ pub struct StartCmd {
     #[clap(short = 'g', long = "guild-id")]
     guild_id: Option<u64>,
 
-    /// Configure the faucet mnemonic in order to send to token from this address.
+    /// Configure the faucet mnemonic in order to send tokens from this address.
     #[clap(short = 'm', long = "mnemonic")]
     mnemonic: Option<String>,
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -118,7 +118,7 @@ impl Default for ChainSection {
 
 /// Faucet configuration section
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct FaucetSection {
     /// The sender mnemonic.
     pub mnemonic: String,


### PR DESCRIPTION
Like title says, add the `--mnemonic` cli argument to set the faucet mnemonic. Alias is `-m`. 
In addition, I've changed the Faucet config serde initialization allowing to omit some config from the `.toml` (like mnemonic) and use default value, to avoid crash app if config is not present in the toml file. 
That allow to set the mnemonic in the command argument and to omit it from the `config.toml`.