### PR TITLE
ci: update version of tj-actions changed-files action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Find changed rust files
         id: changed-rust-cargo
-        uses: tj-actions/changed-files@v29.0.9
+        uses: tj-actions/changed-files@v34
         with:
           files: |
             Cargo.toml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Find changed rust files
         id: changed-rust-files
-        uses: tj-actions/changed-files@v29.0.9
+        uses: tj-actions/changed-files@v34
         with:
           files: |
             **/*.rs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Find change in readme file
         id: readme-change
-        uses: tj-actions/changed-files@v29.0.9
+        uses: tj-actions/changed-files@v34
         with:
           files: |
             README.md


### PR DESCRIPTION
Github action tj-actions/changed-files is updated to version v34. This solves part of the warnings thrown by the lint.yml and publish.yml workflows.

Some warnings are still thrown by lint.yml, build.yml and test.yml. They originate from action-rs/toolchain@v1. The latter action still uses node version 12. The update to version 16 appears to be in progress [here](https://github.com/actions-rs/toolchain/pull/220). 