### PR TITLE
😵 Limit faucet harassing 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 
@@ -53,7 +53,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
         if: steps.changed-rust-cargo.outputs.any_changed == 'true'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 
@@ -102,7 +102,7 @@ jobs:
         if: steps.changed-rust-files.outputs.any_changed == 'true'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 
@@ -124,7 +124,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 
@@ -155,7 +155,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           default: true
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license-file = "LICENSE"
 name = "discord_bot"
 readme = "README.md"
 repository = "https://github.com/okp4/discord-bot"
-rust-version = "1.64"
+rust-version = "1.65"
 version = "0.1.0"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #--- Build stage
-FROM clux/muslrust:1.64.0-stable as builder
+FROM clux/muslrust:1.65.0-stable as builder
 
 WORKDIR /app
 

--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -92,6 +92,7 @@ impl Runnable for StartCmd {
                 |handler| {
                     handler.memo = config.faucet.memo.to_string();
                     handler.batch_window = config.chain.batch_transaction_window;
+                    handler.max_msg = config.chain.max_msg;
                     handler
                 },
             )

--- a/src/cli/commands/start.rs
+++ b/src/cli/commands/start.rs
@@ -93,6 +93,7 @@ impl Runnable for StartCmd {
                     handler.memo = config.faucet.memo.to_string();
                     handler.batch_window = config.chain.batch_transaction_window;
                     handler.max_msg = config.chain.max_msg;
+                    handler.queue_limit = config.chain.queue_limit;
                     handler
                 },
             )

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -102,6 +102,9 @@ pub struct ChainSection {
 
     /// Duration between two transaction batch.
     pub batch_transaction_window: Duration,
+
+    /// Configure the maximum
+    pub max_msg: usize,
 }
 
 impl Default for ChainSection {
@@ -112,6 +115,7 @@ impl Default for ChainSection {
             denom: "know".to_string(),
             prefix: "okp4".to_string(),
             batch_transaction_window: Duration::from_secs(8),
+            max_msg: 7,
         }
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -103,8 +103,12 @@ pub struct ChainSection {
     /// Duration between two transaction batch.
     pub batch_transaction_window: Duration,
 
-    /// Configure the maximum
+    /// Configure the maximum number of message that are sent by transaction
+    /// batch.
     pub max_msg: usize,
+
+    /// Maximum number of transaction waiting in the queue.
+    pub queue_limit: usize,
 }
 
 impl Default for ChainSection {
@@ -116,6 +120,7 @@ impl Default for ChainSection {
             prefix: "okp4".to_string(),
             batch_transaction_window: Duration::from_secs(8),
             max_msg: 7,
+            queue_limit: 1000,
         }
     }
 }

--- a/src/cosmos/faucet/handlers/request_funds.rs
+++ b/src/cosmos/faucet/handlers/request_funds.rs
@@ -1,12 +1,13 @@
 use crate::cosmos::faucet::messages::request_funds::{RequestFunds, RequestFundsResult};
 use crate::cosmos::faucet::Faucet;
-use crate::cosmos::tx::messages::register_msg::RegisterMsg;
-use actix::Handler;
+use crate::cosmos::tx::error::Error::Mailbox;
+use crate::cosmos::tx::messages::register_msg::{RegisterMsg, RegisterMsgResult};
+use actix::{Handler, MailboxError, ResponseFuture};
 use cosmrs::bank::MsgSend;
 use tracing::info;
 
 impl Handler<RequestFunds> for Faucet {
-    type Result = RequestFundsResult;
+    type Result = ResponseFuture<RequestFundsResult>;
 
     fn handle(&mut self, msg: RequestFunds, _: &mut Self::Context) -> Self::Result {
         let msg_send = MsgSend {
@@ -15,9 +16,15 @@ impl Handler<RequestFunds> for Faucet {
             amount: vec![self.amount.clone()],
         };
 
-        self.tx_handler
-            .do_send(RegisterMsg::new(msg_send, msg.requester));
+        info!("✍️ Register request funds for {}", msg.address);
 
-        info!("✍️  Register request funds for {}", msg.address);
+        let tx_handler = self.tx_handler.clone();
+        Box::pin(async move {
+            let result: Result<RegisterMsgResult, MailboxError> = tx_handler
+                .send(RegisterMsg::new(msg_send, msg.requester))
+                .await;
+
+            result.map_err(|e| Mailbox(e.to_string())).and_then(|r| r)
+        })
     }
 }

--- a/src/cosmos/faucet/handlers/request_funds.rs
+++ b/src/cosmos/faucet/handlers/request_funds.rs
@@ -16,7 +16,7 @@ impl Handler<RequestFunds> for Faucet {
         };
 
         self.tx_handler
-            .do_send(RegisterMsg::new(msg_send, Some(msg.requester)));
+            .do_send(RegisterMsg::new(msg_send, msg.requester));
 
         info!("✍️  Register request funds for {}", msg.address);
     }

--- a/src/cosmos/faucet/messages/request_funds.rs
+++ b/src/cosmos/faucet/messages/request_funds.rs
@@ -1,10 +1,11 @@
 //! Holds Request funds messages
+use crate::cosmos::tx::error::Error;
 use actix::Message;
 use cosmrs::AccountId;
 use serenity::model::user::User;
 
 /// Represent the RequestFunds message result
-pub type RequestFundsResult = ();
+pub type RequestFundsResult = Result<(), Error>;
 
 /// Request funds from the faucet message
 #[derive(Message)]

--- a/src/cosmos/tx/error.rs
+++ b/src/cosmos/tx/error.rs
@@ -19,9 +19,21 @@ pub enum Error {
     #[error("An error occur at the grpc client: {0}")]
     Client(crate::cosmos::client::error::Error),
 
+    /// The transaction queue is full.
+    #[error("The transaction queue is full")]
+    QueueFull,
+
+    /// A transaction is already registered for this user
+    #[error("A transaction is already registered for this user")]
+    DuplicateUser,
+
     /// Failed communicate to actix.
     #[error("An error occurs when send message to actix: {0}.")]
     Mailbox(String),
+
+    /// Error occurs to lock mutex
+    #[error("Error occurs to lock mutex")]
+    Lock,
 }
 
 impl From<CosmosErrorReport> for Error {

--- a/src/cosmos/tx/handlers/register_msg.rs
+++ b/src/cosmos/tx/handlers/register_msg.rs
@@ -21,12 +21,14 @@ where
             error!("❌ Failed lock msgs queue, request fund couldn't be registered.");
             return
         };
-        if msgs.iter().find(|f| f.0.id == msg.subscriber.id) == None {
+        if !msgs.iter().any(|f| f.0.id == msg.subscriber.id) {
             info!("🤑 Register transaction for {}", msg.subscriber.name);
             msgs.push_back((msg.subscriber, msg.msg));
-        }
-        else {
-            info!("👮‍ The user {} already register transaction, skip this one.", msg.subscriber.name);
+        } else {
+            info!(
+                "👮‍ The user {} already register transaction, skip this one.",
+                msg.subscriber.name
+            );
         }
     }
 }

--- a/src/cosmos/tx/handlers/register_msg.rs
+++ b/src/cosmos/tx/handlers/register_msg.rs
@@ -6,16 +6,23 @@ use crate::cosmos::tx::TxHandler;
 use actix::dev::ToEnvelope;
 use actix::{Actor, Handler};
 use cosmrs::tx::Msg;
+use tracing::info;
 
 impl<T, R> Handler<RegisterMsg<T>> for TxHandler<T, R>
 where
-    T: Msg + Unpin + 'static,
+    T: Msg + Unpin + 'static + PartialEq,
     R: Actor + Handler<TxResult>,
     R::Context: ToEnvelope<R, TxResult>,
 {
     type Result = RegisterMsgResult;
 
     fn handle(&mut self, msg: RegisterMsg<T>, _: &mut Self::Context) -> Self::Result {
-        self.msgs.push_back((msg.subscriber, msg.msg));
+        if self.msgs.iter().find(|f| f.0.id == msg.subscriber.id) == None {
+            info!("🤑 Register transaction for {}", msg.subscriber.name);
+            self.msgs.push_back((msg.subscriber, msg.msg));
+        }
+        else {
+            info!("👮‍ The user {} already register transaction, skip this one.", msg.subscriber.name);
+        }
     }
 }

--- a/src/cosmos/tx/handlers/register_msg.rs
+++ b/src/cosmos/tx/handlers/register_msg.rs
@@ -1,13 +1,14 @@
 //! Register transaction handler
 
+use crate::cosmos::tx::error::Error::{DuplicateUser, Lock, QueueFull};
 use crate::cosmos::tx::messages::register_msg::{RegisterMsg, RegisterMsgResult};
 use crate::cosmos::tx::messages::response::TxResult;
 use crate::cosmos::tx::TxHandler;
 use actix::dev::ToEnvelope;
 use actix::{Actor, Handler};
 use cosmrs::tx::Msg;
+use tracing::info;
 use tracing::log::warn;
-use tracing::{error, info};
 
 impl<T, R> Handler<RegisterMsg<T>> for TxHandler<T, R>
 where
@@ -18,23 +19,24 @@ where
     type Result = RegisterMsgResult;
 
     fn handle(&mut self, msg: RegisterMsg<T>, _: &mut Self::Context) -> Self::Result {
-        let Ok(mut msgs) = self.msgs_queue.lock() else {
-            error!("❌ Failed lock msgs queue, request fund couldn't be registered.");
-            return
-        };
+        let mut msgs = self.msgs_queue.lock().map_err(|_| Lock)?;
+
         if msgs.len() >= self.queue_limit {
             warn!(
                 "❌ Could not register funds for {}, the queue is full.",
                 msg.subscriber.name
             );
+            Err(QueueFull)
         } else if msgs.iter().any(|f| f.0.id == msg.subscriber.id) {
             info!(
                 "👮‍ The user {} already register transaction, skip this one.",
                 msg.subscriber.name
             );
+            Err(DuplicateUser)
         } else {
             info!("🤑 Register transaction for {}", msg.subscriber.name);
             msgs.push_back((msg.subscriber, msg.msg));
+            Ok(())
         }
     }
 }

--- a/src/cosmos/tx/handlers/register_msg.rs
+++ b/src/cosmos/tx/handlers/register_msg.rs
@@ -16,9 +16,6 @@ where
     type Result = RegisterMsgResult;
 
     fn handle(&mut self, msg: RegisterMsg<T>, _: &mut Self::Context) -> Self::Result {
-        if msg.subscriber.is_some() {
-            self.subscribers.push(msg.subscriber.unwrap())
-        }
-        self.msgs.push(msg.msg);
+        self.msgs.push_back((msg.subscriber, msg.msg));
     }
 }

--- a/src/cosmos/tx/handlers/register_msg.rs
+++ b/src/cosmos/tx/handlers/register_msg.rs
@@ -17,9 +17,10 @@ where
     type Result = RegisterMsgResult;
 
     fn handle(&mut self, msg: RegisterMsg<T>, _: &mut Self::Context) -> Self::Result {
-        if self.msgs.iter().find(|f| f.0.id == msg.subscriber.id) == None {
+        let mut msgs = self.msgs_queue.lock().unwrap();
+        if msgs.iter().find(|f| f.0.id == msg.subscriber.id) == None {
             info!("🤑 Register transaction for {}", msg.subscriber.name);
-            self.msgs.push_back((msg.subscriber, msg.msg));
+            msgs.push_back((msg.subscriber, msg.msg));
         }
         else {
             info!("👮‍ The user {} already register transaction, skip this one.", msg.subscriber.name);

--- a/src/cosmos/tx/handlers/register_msg.rs
+++ b/src/cosmos/tx/handlers/register_msg.rs
@@ -6,7 +6,7 @@ use crate::cosmos::tx::TxHandler;
 use actix::dev::ToEnvelope;
 use actix::{Actor, Handler};
 use cosmrs::tx::Msg;
-use tracing::info;
+use tracing::{error, info};
 
 impl<T, R> Handler<RegisterMsg<T>> for TxHandler<T, R>
 where
@@ -17,7 +17,10 @@ where
     type Result = RegisterMsgResult;
 
     fn handle(&mut self, msg: RegisterMsg<T>, _: &mut Self::Context) -> Self::Result {
-        let mut msgs = self.msgs_queue.lock().unwrap();
+        let Ok(mut msgs) = self.msgs_queue.lock() else {
+            error!("❌ Failed lock msgs queue, request fund couldn't be registered.");
+            return
+        };
         if msgs.iter().find(|f| f.0.id == msg.subscriber.id) == None {
             info!("🤑 Register transaction for {}", msg.subscriber.name);
             msgs.push_back((msg.subscriber, msg.msg));

--- a/src/cosmos/tx/handlers/trigger.rs
+++ b/src/cosmos/tx/handlers/trigger.rs
@@ -1,7 +1,5 @@
 //! Trigger transaction handler
 
-use std::cmp::min;
-use std::collections::VecDeque;
 use crate::cosmos::client::messages::broadcast_tx::{BroadcastTx, BroadcastTxResult};
 use crate::cosmos::client::messages::get_account::{GetAccount, GetAccountResult};
 use crate::cosmos::tx::error::Error;
@@ -12,6 +10,8 @@ use actix::dev::ToEnvelope;
 use actix::{Actor, ActorFutureExt, Handler, MailboxError, ResponseActFuture, WrapFuture};
 use cosmrs::tx::{Body, Msg};
 use serenity::model::user::User;
+use std::cmp::min;
+use std::collections::VecDeque;
 use tracing::info;
 use tracing::log::error;
 
@@ -29,8 +29,9 @@ where
             return Box::pin(async {}.into_actor(self));
         }
 
-        let (subscribers, msgs): (Vec<User>, Vec<T>) = self.msgs
-            .drain(..min(self.msgs.len(),2))
+        let (subscribers, msgs): (Vec<User>, Vec<T>) = self
+            .msgs
+            .drain(..min(self.msgs.len(), self.max_msg))
             .map(|it| (it.0, it.1))
             .unzip();
 

--- a/src/cosmos/tx/handlers/trigger.rs
+++ b/src/cosmos/tx/handlers/trigger.rs
@@ -23,7 +23,10 @@ where
     type Result = ResponseActFuture<Self, TriggerTxResult>;
 
     fn handle(&mut self, msg: TriggerTx, _ctx: &mut Self::Context) -> Self::Result {
-        let mut msgs_queue = self.msgs_queue.lock().unwrap();
+        let Ok(mut msgs_queue) = self.msgs_queue.lock() else {
+            error!("❌ Failed lock msgs queue, request fund couldn't be registered.");
+            return Box::pin(async {}.into_actor(self));
+        };
         let msgs_queue_len = msgs_queue.len();
 
         if msgs_queue.is_empty() {

--- a/src/cosmos/tx/handlers/trigger.rs
+++ b/src/cosmos/tx/handlers/trigger.rs
@@ -11,7 +11,6 @@ use actix::{Actor, ActorFutureExt, Handler, MailboxError, ResponseActFuture, Wra
 use cosmrs::tx::{Body, Msg};
 use serenity::model::user::User;
 use std::cmp::min;
-use std::collections::VecDeque;
 use tracing::info;
 use tracing::log::error;
 

--- a/src/cosmos/tx/handlers/trigger.rs
+++ b/src/cosmos/tx/handlers/trigger.rs
@@ -23,14 +23,16 @@ where
     type Result = ResponseActFuture<Self, TriggerTxResult>;
 
     fn handle(&mut self, msg: TriggerTx, _ctx: &mut Self::Context) -> Self::Result {
-        if self.msgs.is_empty() {
+        let mut msgs_queue = self.msgs_queue.lock().unwrap();
+        let msgs_queue_len = msgs_queue.len();
+
+        if msgs_queue.is_empty() {
             info!("🥹 No message to submit");
             return Box::pin(async {}.into_actor(self));
         }
 
-        let (subscribers, msgs): (Vec<User>, Vec<T>) = self
-            .msgs
-            .drain(..min(self.msgs.len(), self.max_msg))
+        let (subscribers, msgs): (Vec<User>, Vec<T>) = msgs_queue
+            .drain(..min(msgs_queue_len, self.max_msg))
             .map(|it| (it.0, it.1))
             .unzip();
 

--- a/src/cosmos/tx/messages/register_msg.rs
+++ b/src/cosmos/tx/messages/register_msg.rs
@@ -1,11 +1,12 @@
 //! Register transaction message
 
+use crate::cosmos::tx::error::Error;
 use actix::Message;
 use cosmrs::tx::Msg;
 use serenity::model::user::User;
 
 /// Result of a RegisterMsg message.
-pub type RegisterMsgResult = ();
+pub type RegisterMsgResult = Result<(), Error>;
 
 /// Register transaction's message actor message.
 #[derive(Message)]

--- a/src/cosmos/tx/messages/register_msg.rs
+++ b/src/cosmos/tx/messages/register_msg.rs
@@ -18,7 +18,7 @@ where
     pub msg: T,
 
     /// Transaction subscriber
-    pub subscriber: Option<User>,
+    pub subscriber: User,
 }
 
 impl<T> RegisterMsg<T>
@@ -26,7 +26,7 @@ where
     T: Msg,
 {
     /// Create a new RegisterMsg.
-    pub fn new(msg: T, subscriber: Option<User>) -> Self
+    pub fn new(msg: T, subscriber: User) -> Self
     where
         T: Msg,
     {

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -6,15 +6,16 @@ pub mod error;
 pub mod handlers;
 pub mod messages;
 
-use std::collections::VecDeque;
 use crate::cosmos::client::account::Account;
 use crate::cosmos::client::Client;
 use crate::cosmos::tx::error::Error;
 use crate::cosmos::tx::messages::response::TxResult;
 use actix::{Actor, Addr, Handler};
 use cosmos_sdk_proto::cosmos::auth::v1beta1::BaseAccount;
+use cosmrs::bip32::secp256k1::sha2::digest::typenum::UInt;
 use cosmrs::tx::{Body, Fee, Msg, SignDoc, SignerInfo};
 use serenity::model::user::User;
+use std::collections::VecDeque;
 use std::time::Duration;
 use tonic::transport::Channel;
 
@@ -35,6 +36,8 @@ where
     pub fee: Fee,
     /// Duration between two transactions.
     pub batch_window: Duration,
+    /// Number of max message per transactions
+    pub max_msg: usize,
     /// Contains the batch of transaction message to sent as prost::Any.
     msgs: VecDeque<(User, T)>,
     /// GRPC client to send transaction.
@@ -65,6 +68,7 @@ where
             memo: "".to_string(),
             fee,
             batch_window: Duration::new(8, 0),
+            max_msg: 7,
             msgs: VecDeque::new(),
             grpc_client,
             response_handler: None,

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod handlers;
 pub mod messages;
 
+use std::collections::VecDeque;
 use crate::cosmos::client::account::Account;
 use crate::cosmos::client::Client;
 use crate::cosmos::tx::error::Error;
@@ -35,9 +36,7 @@ where
     /// Duration between two transactions.
     pub batch_window: Duration,
     /// Contains the batch of transaction message to sent as prost::Any.
-    msgs: Vec<T>,
-    /// Contains the list of all user that request transaction.
-    subscribers: Vec<User>,
+    msgs: VecDeque<(User, T)>,
     /// GRPC client to send transaction.
     grpc_client: Addr<Client<Channel>>,
     /// Hold address of actor that will receive message when a transaction has been broadcasted.
@@ -66,8 +65,7 @@ where
             memo: "".to_string(),
             fee,
             batch_window: Duration::new(8, 0),
-            msgs: vec![],
-            subscribers: vec![],
+            msgs: VecDeque::new(),
             grpc_client,
             response_handler: None,
         };

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -38,6 +38,8 @@ where
     pub batch_window: Duration,
     /// Number of max message per transactions
     pub max_msg: usize,
+    /// Number of message that can be in the queue
+    pub queue_limit: usize,
     /// Contains the batch of transaction message to sent as prost::Any.
     msgs_queue: Arc<Mutex<VecDeque<(User, T)>>>,
     /// GRPC client to send transaction.
@@ -69,6 +71,7 @@ where
             fee,
             batch_window: Duration::new(8, 0),
             max_msg: 7,
+            queue_limit: 1000,
             msgs_queue: Arc::new(Mutex::new(VecDeque::new())),
             grpc_client,
             response_handler: None,

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -12,7 +12,6 @@ use crate::cosmos::tx::error::Error;
 use crate::cosmos::tx::messages::response::TxResult;
 use actix::{Actor, Addr, Handler};
 use cosmos_sdk_proto::cosmos::auth::v1beta1::BaseAccount;
-use cosmrs::bip32::secp256k1::sha2::digest::typenum::UInt;
 use cosmrs::tx::{Body, Fee, Msg, SignDoc, SignerInfo};
 use serenity::model::user::User;
 use std::collections::VecDeque;

--- a/src/cosmos/tx/mod.rs
+++ b/src/cosmos/tx/mod.rs
@@ -15,6 +15,7 @@ use cosmos_sdk_proto::cosmos::auth::v1beta1::BaseAccount;
 use cosmrs::tx::{Body, Fee, Msg, SignDoc, SignerInfo};
 use serenity::model::user::User;
 use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tonic::transport::Channel;
 
@@ -38,7 +39,7 @@ where
     /// Number of max message per transactions
     pub max_msg: usize,
     /// Contains the batch of transaction message to sent as prost::Any.
-    msgs: VecDeque<(User, T)>,
+    msgs_queue: Arc<Mutex<VecDeque<(User, T)>>>,
     /// GRPC client to send transaction.
     grpc_client: Addr<Client<Channel>>,
     /// Hold address of actor that will receive message when a transaction has been broadcasted.
@@ -68,7 +69,7 @@ where
             fee,
             batch_window: Duration::new(8, 0),
             max_msg: 7,
-            msgs: VecDeque::new(),
+            msgs_queue: Arc::new(Mutex::new(VecDeque::new())),
             grpc_client,
             response_handler: None,
         };

--- a/src/discord/discord_server/cmd/request.rs
+++ b/src/discord/discord_server/cmd/request.rs
@@ -1,9 +1,12 @@
 //! Holds request commands functions
 
-use crate::cosmos::faucet::messages::request_funds::RequestFunds;
+use crate::cosmos::faucet::messages::request_funds::{RequestFunds, RequestFundsResult};
+use crate::cosmos::tx::error::Error as RequestError;
+use crate::cosmos::tx::error::Error::Mailbox;
 use crate::discord::discord_server::cmd::CommandExecutable;
 use crate::discord::discord_server::error::Error;
 use crate::discord::discord_server::Actors;
+use actix::MailboxError;
 use serenity::async_trait;
 use serenity::client::Context;
 use serenity::model::application::interaction::application_command::ApplicationCommandInteraction;
@@ -29,11 +32,21 @@ impl CommandExecutable for RequestCmd {
         info!("💰 request fund slash command");
 
         let msg = if let Ok(address) = self.address.parse() {
-            actors.faucet.do_send(RequestFunds {
-                address,
-                requester: command.user.clone(),
-            });
-            "📥 Funds has been successfully requested.".to_string()
+            let request: Result<RequestFundsResult, MailboxError> = actors
+                .faucet
+                .send(RequestFunds {
+                    address,
+                    requester: command.user.clone(),
+                })
+                .await;
+            match request.map_err(|e| Mailbox(e.to_string())).and_then(|r| r) {
+                Ok(_) => "📥 Funds has been successfully requested.".to_string(),
+                Err(err) => match err {
+                    RequestError::QueueFull => "❌ Queue is full, please wait before re-submit funds request.".to_string(),
+                    RequestError::DuplicateUser => "❌ You have already request funds, please wait before re-submit your request.".to_string(),
+                    _ => "❌ An error occurs, please try again.".to_string(),
+                }
+            }
         } else {
             format!(
                 "❌ Your wallet address `{}` seems to be wrong.",

--- a/src/discord/discord_server/cmd/request.rs
+++ b/src/discord/discord_server/cmd/request.rs
@@ -43,7 +43,7 @@ impl CommandExecutable for RequestCmd {
                 Ok(_) => "📥 Funds has been successfully requested.".to_string(),
                 Err(err) => match err {
                     RequestError::QueueFull => "❌ Queue is full, please wait before re-submit funds request.".to_string(),
-                    RequestError::DuplicateUser => "❌ You have already request funds, please wait before re-submit your request.".to_string(),
+                    RequestError::DuplicateUser => "❌ You have already requested funds, please wait before re-submiting your request.".to_string(),
                     _ => "❌ An error occurs, please try again.".to_string(),
                 }
             }

--- a/src/discord/discord_server/mod.rs
+++ b/src/discord/discord_server/mod.rs
@@ -237,7 +237,7 @@ pub async fn start(
             info!("🛰 Connection to cosmos grpc endpoint successful");
             info!("🚀 Booting the Bot...");
 
-            Client::builder(&token, intents)
+            Client::builder(token, intents)
                 .event_handler(handler)
                 .await
                 .map_err(|_| Error::from(ErrorKind::Client("Failed to create client".to_string())))


### PR DESCRIPTION
#### 📝 Description 

Due to the faucet message harassing, it was necessary to improve message handling to avoid spamming. The solution used in this PR bring a new messages queue linked to the sender, on each transaction batch, the first N transaction message (config set in config file) is sent with the discord message. The queue contains the list of all transaction pending, if user try to request funds and already waiting in the queue, the transaction is skipped. The queue is also limited in size, if the size limit is reached, transaction is skipped also. 

New error messages has been configured to be sent to the discord user if the queue is full or if the user already request funds. 

#### ⚙️ Configuration

New configuration keys has been added to configure the maximum number of message that can be sent by transaction batch, by default I set it to 7 transactions and the maximum number of transaction that can be register in the waiting queue, by default 1000 transactions. 

```toml
[chain]
max_msg = 7
queue_limit = 1000
``` 

#### 🦀 Rust update

I've also update the rust toolchain to the latest version 1.65. It's allow me to use the new [if-else statement](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements) that is wonderful 😇.  https://github.com/okp4/discord-bot/pull/113/commits/297fc6e8b48f39e5d0a6060056482e7db77380a8

Closes #112 