### PR TITLE
Fix test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install grcov
         run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
 
+      - name: Install llvm-tools
+        run: rustup component add llvm-tools-preview
+
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -70,12 +70,11 @@ args = ["test", "--tests", "--workspace", "--locked", "--all-features"]
 command = "cargo"
 dependencies = ["build-coverage"]
 description = "Run all unit tests."
-env = { LLVM_PROFILE_FILE = "default.profraw", RUST_BACKTRACE = 1 }
-install_crate = { rustup_component_name = "llvm-tools-preview" }
+env = { LLVM_PROFILE_FILE = "default_%p.profraw", RUST_BACKTRACE = 1, RUSTFLAGS = "-Cinstrument-coverage" }
 
 [tasks.test-coverage]
 dependencies = ["test"]
-install_crate = { crate_name = "grcov" }
+install_crate = { crate_name = "grcov", rustup_component_name = "llvm-tools-preview", binary = "grcov", test_arg = "--help" }
 script = '''
 grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "*cargo*" -o coverage.lcov
 '''


### PR DESCRIPTION
`cargo-make` released a new version (0.36.3) which, for some reason, caused the test workflow to fail. This PR make it work again 🤷